### PR TITLE
Change image to be more flexible and robust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM deltares/swan
 ADD run_docker.sh /opt/run_docker.sh
 RUN chmod +x /opt/run_docker.sh
+ENTRYPOINT ["bash", "/opt/run_docker.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 rm -fr ./output
-docker run -v $(PWD)/example/:/data/RUN -v $(pwd)/output:/output -e INPUT=f31har01 -it nerdalize/swan
+docker run -v $(pwd)/example/:/data/RUN -v $(pwd)/output:/output -it nerdalize/swan /data/RUN/f31har01.swn

--- a/run_docker.sh
+++ b/run_docker.sh
@@ -1,13 +1,35 @@
 #!/bin/bash
+
+set -e
+
+# Process configuration a bit
+INPUTFILE=$1
+WORKDIR=`dirname "$1"`
+
+# Adopt naming convention from input file
+if [[ $INPUTFILE =~ \.[A-Z]+$ ]]
+then
+    OUTPUTFILE="${INPUTFILE%.*}.PRT"
+else
+    OUTPUTFILE="${INPUTFILE%.*}.prt"
+fi
+
 echo ----------------------------------------------------------------------
 echo $SWANEXE
 echo with OpenMP on linux cluster, Nerdalize mod.
-echo SGE_O_WORKDIR : $SWANDIR
+#echo SGE_O_WORKDIR : $SWANDIR
+echo INPUT FILE : $INPUTFILE
+echo WORKING DIRECTORY : $WORKDIR
+echo OUTPUT FILE : $OUTPUTFILE
 echo ----------------------------------------------------------------------
-### Copy swaninit
-cd /data/RUN
-### General, start SWAN.
-cp $1.SWN INPUT
+
+# Switch to base working directory
+cd $WORKDIR
+
+# Rename input file for SWAN
+cp $INPUTFILE INPUT
+
+# Run SWAN
 starttime=`date +%s`
 $SWANEXE
 endtime=`date +%s`
@@ -17,11 +39,10 @@ echo ----------------------------------------------------------------------
 echo "The run was completed after $((runtime / 60)) minutes"
 echo ----------------------------------------------------------------------
 
-cp PRINT "$1".PRT
+# Process generated files into output and delete temporary files
+mv PRINT $OUTPUTFILE
 rm INPUT
-rm PRINT
-rm swaninit
-rm norm_end
+rm -f swaninit
+rm -f norm_end
 
-mkdir -p /output
-cp -R /data/RUN/* /output
+cp -r . /output/


### PR DESCRIPTION
I've changed the script in the Docker container to be more robust by aborting on every error and checking if, for example, the input file actually exists.

Additionally I've changed the input parameters to directly refer to the absolute path of the `.swn` file like so:

```
nerd job run --name=swan-test-example --vcpu=8 --memory=11 --input=./example:/data/RUN --output=/output nerdalize/swan:test /data/RUN/f31har01.swn

nerd job run --name=swan-test-real-2 --vcpu=8 --memory=11 --input=./test:/data/RUN --output=/output nerdalize/swan:test /data/RUN/computations/wbi2017productie/rmmu11d022s01/rmmu11d022s01.swn
```

This way it supports (nearly) any input directory structure. After computation completes the full input is copied to the `/output` to carry over any desired files.

It appears to now support both the SWAN example and a real workload (HKV).